### PR TITLE
Specify extended Index keys and update 0.8.11 docs

### DIFF
--- a/docs/cad/003_encoding/index.md
+++ b/docs/cad/003_encoding/index.md
@@ -544,7 +544,7 @@ A Set is encoded exactly the same as a Map, except:
 ### `0x84` Index
 
 ```
-0x84 <VLQ Count = n> <Entry> <Depth> <Mask> <Child>(repeated 1-16 times)
+0x84 <VLQ Count = n> <Entry> <VLQ Depth> <Mask> <Child>(repeated 1-16 times)
 
 Where:
 
@@ -552,7 +552,7 @@ Where:
 - 0x00                   (if no entry present at this position in Index)
 - 0x20 <Key> <Value>     (if entry present)
 
-<Depth> is an unsigned byte indicating the hex digit at which the entry / branch occurs. If an entry is present, depth must match the hex length of the entry key
+<VLQ Depth> is a canonical unsigned VLQ Count indicating the hex digit at which the entry / branch occurs. If an entry is present, depth must match the effective hex length of the entry key. Multi-entry nodes have depths from 0 to 509 inclusive; depth 510 is reserved for the singleton form, where the depth is omitted. Depths 0 to 127 therefore retain their historical one-byte encoding.
 
 <Mask> is a 16 bit bitmap of which child Index nodes are present at the given depth (low bit = `0` ... high bit = `F`)
 
@@ -568,7 +568,7 @@ An Index serves as a specialised map with ordered keys. Logically, it is a mappi
 
 Key values MUST be Blobs, Strings, Addresses, Keywords or Symbols. These are regarded as "BlobLike" because they can be considered as a sequence of bytes like a Blob.
 
-This encoding ensures that entries are encoded in lexicographic ordering. Unlike the hash based Maps, an Index is constrained to use only BlobLike keys, and cannot store two keys which have the same Blob representation (though the keys will retain their original type).
+This encoding ensures that entries are encoded in lexicographic ordering. Unlike the hash based Maps, an Index is constrained to use only BlobLike keys, and cannot store two keys which have the same Blob representation (though the keys will retain their original type). Index comparison is limited to the first 255 bytes, so keys which share that complete prefix identify the same entry.
 
 ### `0x88` Syntax
 

--- a/docs/cad/026_lisp/index.md
+++ b/docs/cad/026_lisp/index.md
@@ -360,7 +360,7 @@ Internally sets are implemented as radix trees based on the hash value of elemen
 
 #### Indexes
 
-Indexes are specialised ordered maps that support "Blob-Like" keys only (Blobs, Strings, Addresses, Keywords and Symbols). Entries are sorted based on the byte values of the keys, up to a maximum of 32 bytes.
+Indexes are specialised ordered maps that support "Blob-Like" keys only (Blobs, Strings, Addresses, Keywords and Symbols). Entries are sorted based on the first 255 byte values of the keys. Keys which share the same first 255 bytes identify the same entry.
 
 ```clojure
 ;; Construct an index, note that the map is sorted in order

--- a/docs/tutorial/client-sdks/java/index.md
+++ b/docs/tutorial/client-sdks/java/index.md
@@ -28,14 +28,14 @@ This guide uses the **CVM-typed client**, `convex.api.Convex` — you work with 
 <dependency>
     <groupId>world.convex</groupId>
     <artifactId>convex-java</artifactId>
-    <version>0.8.8</version>
+    <version>0.8.11</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'world.convex:convex-java:0.8.8'
+implementation 'world.convex:convex-java:0.8.11'
 ```
 
 ## Quick Example

--- a/docs/tutorial/client-sdks/java/quickstart.md
+++ b/docs/tutorial/client-sdks/java/quickstart.md
@@ -46,7 +46,7 @@ Create a new Maven project with `pom.xml`:
         <dependency>
             <groupId>world.convex</groupId>
             <artifactId>convex-java</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.11</version>
         </dependency>
     </dependencies>
 </project>
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'world.convex:convex-java:0.8.8'
+    implementation 'world.convex:convex-java:0.8.11'
 }
 
 java {

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -109,7 +109,7 @@ Connect to Convex from your application using official client libraries:
   *Production ready* • `npm install @convex-world/convex-ts`
 
 - **[Java](/docs/tutorial/client-sdks/java)** - For JVM applications, Android, enterprise systems
-  *Production ready* • `world.convex:convex-java:0.8.8`
+  *Production ready* • `world.convex:convex-java:0.8.11`
 
 - **[Python](/docs/tutorial/client-sdks/python)** - For Python applications, scripting, data science
   *Production ready* • `pip install convex-sdk`

--- a/docs/tutorial/peer-operations/local-testnets.md
+++ b/docs/tutorial/peer-operations/local-testnets.md
@@ -168,7 +168,7 @@ Run a local peer with a full GUI for interactive development.
 **Download**:
 ```bash
 # Linux/Mac
-wget https://github.com/Convex-Dev/convex/releases/download/0.8.8/convex.jar
+wget https://github.com/Convex-Dev/convex/releases/download/0.8.11/convex.jar
 
 # Or build from source
 git clone https://github.com/Convex-Dev/convex.git
@@ -345,7 +345,7 @@ jobs:
 
       - name: Start Local Peer
         run: |
-          wget https://github.com/Convex-Dev/convex/releases/download/0.8.8/convex.jar
+          wget https://github.com/Convex-Dev/convex/releases/download/0.8.11/convex.jar
           java -jar convex.jar local start --api-port 8080 &
           sleep 10
 

--- a/docs/tutorial/peer-operations/manual-deployment.md
+++ b/docs/tutorial/peer-operations/manual-deployment.md
@@ -58,7 +58,7 @@ mkdir -p /opt/convex
 cd /opt/convex
 
 # Download latest release
-wget https://github.com/Convex-Dev/convex/releases/download/0.8.8/convex.jar
+wget https://github.com/Convex-Dev/convex/releases/download/0.8.11/convex.jar
 
 # Verify download
 java -jar convex.jar version
@@ -283,7 +283,7 @@ tar -czf backup-$(date +%Y%m%d).tar.gz /opt/convex/data
 
 # Download new version
 cd /opt/convex
-wget https://github.com/Convex-Dev/convex/releases/download/0.8.8/convex.jar \
+wget https://github.com/Convex-Dev/convex/releases/download/0.8.11/convex.jar \
   -O convex.jar.new
 
 # Replace JAR


### PR DESCRIPTION
Specifies the extended Index depth encoding introduced for 0.8.11: canonical unsigned VLQ depths, byte-for-byte compatibility through depth 127, a 255-byte comparison limit, and the singleton boundary at depth 510. Also updates Java dependency and release download examples to 0.8.11.\n\nCloses #86